### PR TITLE
fixed php mysql extension. mysqlnd is required by DF.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER David Weiner<davidweiner@dreamfactory.com>
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && \
-    apt-get install -y git-core curl apache2 php5 php5-common php5-cli php5-curl php5-json php5-mcrypt php5-mysql php5-pgsql php5-sqlite && \
+RUN apt-get update && apt-get install -y \
+    git-core curl apache2 php5 php5-common php5-cli php5-curl php5-json php5-mcrypt php5-mysqlnd php5-pgsql php5-sqlite && \
     rm -rf /var/lib/apt/lists/*
 
 # install composer


### PR DESCRIPTION
upstream merged my PR, doing the same (https://github.com/dreamfactorysoftware/df-docker/pull/15)
